### PR TITLE
Remove dynip.rothen.com

### DIFF
--- a/check-rbl.pl
+++ b/check-rbl.pl
@@ -130,7 +130,6 @@ my @rbl=(
 	'duinv.aupads.org',
 	'dynablock.sorbs.net',
 	'residential.block.transip.nl',
-	'dynip.rothen.com',
 	'dul.blackhole.cantv.net',
 	'mail.people.it',
 	'blacklist.sci.kun.nl',


### PR DESCRIPTION
rothen.com disappeared and the block list [is dysfunctional since at least September 30](https://www.dnsbl.info/dnsbl-details.php?dnsbl=dynip.rothen.com).